### PR TITLE
add UTF16 encoding according to aapt and support textTag in mainfest

### DIFF
--- a/Iteedee.ApkReader/APKManifest.cs
+++ b/Iteedee.ApkReader/APKManifest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -14,6 +14,8 @@ namespace Iteedee.ApkReader
         public static int endDocTag = 0x00100101;
         public static int startTag = 0x00100102;
         public static int endTag = 0x00100103;
+        public static int textTag = 0x00100104;
+
         public string ReadManifestFileIntoXml(byte[] manifestFileData)
         {
             if (manifestFileData.Length == 0)
@@ -139,8 +141,22 @@ namespace Iteedee.ApkReader
                     break;
 
                 }
-                else
-                {
+                else if (tag0 == textTag) { 
+                    // code "copied" https://github.com/mikandi/php-apk-parser/blob/fixed-mikandi-version/lib/ApkParser/XmlParser.php
+                    uint sentinal = 0xffffffff;
+                    while (off < manifestFileData.Length) {
+                        uint curr = (uint)LEW(manifestFileData, off);
+                        off += 4;
+                        if (off > manifestFileData.Length) {
+                            throw new Exception("Sentinal not found before end of file");
+                        }                        
+                        if (curr == sentinal && sentinal == 0xffffffff) {
+                            sentinal = 0x00000000;
+                        } else if (curr == sentinal) {
+                            break;
+                        }                            
+                    }
+                } else {
                     prt("  Unrecognized tag code '" + tag0.ToString("X")
                       + "' at offset " + off);
                     break;

--- a/Iteedee.ApkReader/APKManifest.cs
+++ b/Iteedee.ApkReader/APKManifest.cs
@@ -11,6 +11,7 @@ namespace Iteedee.ApkReader
         private string result = "";
         // decompressXML -- Parse the 'compressed' binary form of Android XML docs 
         // such as for AndroidManifest.xml in .apk files
+        public static int startDocTag = 0x00100100;
         public static int endDocTag = 0x00100101;
         public static int startTag = 0x00100102;
         public static int endTag = 0x00100103;
@@ -85,6 +86,7 @@ namespace Iteedee.ApkReader
             int off = xmlTagOff;
             int indent = 0;
             int startTagLineNo = -2;
+            int startDocTagCounter = 1;
             while (off < manifestFileData.Length)
             {
                 int tag0 = LEW(manifestFileData, off);
@@ -125,7 +127,6 @@ namespace Iteedee.ApkReader
                     }
                     prtIndent(indent, "<" + name + sb + ">");
                     indent++;
-
                 }
                 else if (tag0 == endTag)
                 { // XML END TAG
@@ -136,10 +137,16 @@ namespace Iteedee.ApkReader
                     //tr.parent();  // Step back up the NobTree
 
                 }
+                else if (tag0 == startDocTag)
+                {
+                    startDocTagCounter++;
+                    off += 4;
+                }
                 else if (tag0 == endDocTag)
                 {  // END OF XML DOC TAG
-                    break;
-
+                    startDocTagCounter--;
+                    if (startDocTagCounter == 0)
+                        break;
                 }
                 else if (tag0 == textTag) { 
                     // code "copied" https://github.com/mikandi/php-apk-parser/blob/fixed-mikandi-version/lib/ApkParser/XmlParser.php


### PR DESCRIPTION
according to aapt source code, UTF8/UTF16 string can be extracted by length, The length of string is stored in the string pool in front of each string. and we don't need to finish utf8 string by '\0'

in the manifest, textTag (0x00100104) will cause "unknown tag error", just skip it.